### PR TITLE
#94 Flask api Deployment with Lambda

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -1,0 +1,38 @@
+service: flask-api-lambda
+
+provider:
+  name: aws
+  runtime: python3.12.2
+  region: us-east-1
+
+functions:
+  api:
+    handler: wsgi_handler.handler
+    events:
+      - http:
+          path: /{proxy+}  
+          method: any
+
+plugins:
+  - serverless-wsgi
+  - serverless-python-requirements
+  - serverless-offline
+
+custom:
+  wsgi:
+    app: Servercode.application.AppServer.app
+    packRequirements: true
+
+package:
+  exclude:
+    - ci-info/**
+    - isodate/**
+    - looseversion/**
+    - networkx/**
+    - prov/**
+    - python-dateutil/**
+    - pytz/**
+    - traits/**
+    - tzdata/**
+
+      


### PR DESCRIPTION
Fixes #94

**What was changed?**

I added a serverless.yml file in the root of the repository so I could see if the 'serverless deploy' command could work with our flask.

**Why was it changed?**

I am starting to work on deployment so we first need to test in AWS lambda is possible with our program.

**How was it changed?**

I added the serverless.yml code with the necessary inputs but I am still trying look at which packages are necessary and which are not since lambda limits the size the program could offer. This is still a work in progress as I have not been able to run it yet because I still need to check if the flask app works with AWS lambda. 

Not shown in the code but I am attempting/researching using something called zappa that could potentially simplify the process of deploying to AWS lambda from Flask.
  
I also finished the lambda lab but it seems like I will not be doing any of what its taught me at least for this sprint so far.
![Screenshot 2024-10-14 140545](https://github.com/user-attachments/assets/ffa4b390-1501-4bfc-8e02-8187553e43ab)

