### PR TITLE
Fixing BubbleScan_AI import error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: BubbleScan Release
 on:
   push:
     branches:
-      - main
+      - fixingAIError
 
 jobs:
   build-windows:

--- a/BubbleScan.sh
+++ b/BubbleScan.sh
@@ -32,7 +32,7 @@ pip uninstall -y pathlib 2>/dev/null || echo "pathlib was not reinstalled."
 # Platform-specific builds
 
 echo "Building Windows binary..."
-pyinstaller --onefile --name BubbleScan-Windows.exe --add-data "application/static;static" --add-data "application/logging.conf:." --hidden-import=fitz application/AppServer.py
+pyinstaller --onefile --name BubbleScan-Windows.exe --add-data "application/static;static" --add-data "application/logging.conf:." --hidden-import=BubbleScan_AI --hidden-import=fitz application/AppServer.py
 
 
 

--- a/BubbleScan.sh
+++ b/BubbleScan.sh
@@ -32,7 +32,7 @@ pip uninstall -y pathlib 2>/dev/null || echo "pathlib was not reinstalled."
 # Platform-specific builds
 
 echo "Building Windows binary..."
-pyinstaller --onefile --name BubbleScan-Windows.exe --add-data "application/static;static" --add-data "application/logging.conf:." --add-data "BubbleScan_AI" --hidden-import=fitz application/AppServer.py
+pyinstaller --onefile --name BubbleScan-Windows.exe --add-data "application/static;static" --add-data "application/logging.conf:." --add-data "BubbleScan_AI:BubbleScan_AI" --hidden-import=fitz application/AppServer.py
 
 
 

--- a/BubbleScan.sh
+++ b/BubbleScan.sh
@@ -25,6 +25,7 @@ pip install --no-cache-dir -r requirements.txt
 pip install werkzeug
 pip install flask
 pip install pyinstaller
+pip install opencv-python
 
 # Check again to ensure pathlib is uninstalled
 pip uninstall -y pathlib 2>/dev/null || echo "pathlib was not reinstalled."

--- a/BubbleScan.sh
+++ b/BubbleScan.sh
@@ -33,7 +33,7 @@ pip uninstall -y pathlib 2>/dev/null || echo "pathlib was not reinstalled."
 # Platform-specific builds
 
 echo "Building Windows binary..."
-pyinstaller --onefile --name BubbleScan-Windows.exe --add-data "application/static;static" --add-data "application/logging.conf:." --add-data "BubbleScan_AI:BubbleScan_AI" --hidden-import=fitz application/AppServer.py
+pyinstaller --onefile --name BubbleScan-Windows.exe --add-data "application/static;static" --add-data "application/logging.conf:." --add-data "BubbleScan_AI:BubbleScan_AI" --hidden-import=cv2 --hidden-import=fitz application/AppServer.py
 
 
 

--- a/BubbleScan.sh
+++ b/BubbleScan.sh
@@ -32,7 +32,7 @@ pip uninstall -y pathlib 2>/dev/null || echo "pathlib was not reinstalled."
 # Platform-specific builds
 
 echo "Building Windows binary..."
-pyinstaller --onefile --name BubbleScan-Windows.exe --add-data "application/static;static" --add-data "application/logging.conf:." --hidden-import=BubbleScan_AI --hidden-import=fitz application/AppServer.py
+pyinstaller --onefile --name BubbleScan-Windows.exe --add-data "application/static;static" --add-data "application/logging.conf:." --add-data "BubbleScan_AI" --hidden-import=fitz application/AppServer.py
 
 
 

--- a/BubbleScanMac.sh
+++ b/BubbleScanMac.sh
@@ -23,11 +23,12 @@ pip install --no-cache-dir -r requirements.txt
 pip install werkzeug
 pip install flask
 pip install pyinstaller
+pip install opencv-python
 
 pip uninstall -y pathlib 2>/dev/null || echo "pathlib was not reinstalled."
 
 echo "Building macOS binary..."
-pyinstaller --onefile --name BubbleScan-macOS --add-data "application/static:static" --add-data "application/logging.conf:." --hidden-import=flask --hidden-import=werkzeug --hidden-import=fitz application/AppServer.py
+pyinstaller --onefile --name BubbleScan-macOS --add-data "application/static:static" --add-data "application/logging.conf:." --add-data "BubbleScan_AI:BubbleScan_AI" --hidden-import=cv2 --hidden-import=flask --hidden-import=werkzeug --hidden-import=fitz application/AppServer.py
 
 # Deactivate the virtual environment
 deactivate


### PR DESCRIPTION
**What was changed?**

*Changed mac and windows build scripts so it now detects the moved BubbleScan_AI folder*

**Why was it changed?**

*We were getting an import error every time running a build script and release executable*

![Screenshot 2024-12-02 014409](https://github.com/user-attachments/assets/4006a10d-caef-4efa-9c07-85d7af4925c1)


**How was it changed?**

*Changed the pyinstaller exe command to --add-data "BubbleScan_AI:BubbleScan_AI" and --hidden-import=cv2*

